### PR TITLE
Move arrow to Suggests to appease CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,10 +23,10 @@ Imports:
     checkmate,
     rlang,
     dplyr,
-    arrow,
     lobstr,
     magrittr
-Suggests: 
+Suggests:
+    arrow,
     testthat (>= 3.0.0),
     spelling
 Config/testthat/edition: 3
@@ -34,3 +34,4 @@ Depends:
     R (>= 2.10)
 LazyData: true
 Language: en-US
+Additional_repositories: https://p3m.dev/cran/2024-02-02/

--- a/R/fetch_data.R
+++ b/R/fetch_data.R
@@ -17,7 +17,7 @@
 #' @export
 #' @importFrom rlang .data
 #'
-#' @examples
+#' @examplesIf requireNamespace("arrow", quietly = TRUE)
 #' \dontrun{
 #' fetch_data(
 #'     code_muni = 3304557,
@@ -37,6 +37,14 @@ fetch_data <- function(code_muni, product, indicator, statistics, date_start, da
   checkmate::assert_date(date_end, lower = date_start)
 
   # Check Arrow capabilities
+  if(!requireNamespace("arrow", quietly = TRUE)){
+    msg <- paste(
+      "The 'arrow' package is required but is not available. Install it with:",
+      'install.packages("arrow", repos = c("https://p3m.dev/cran/2024-02-02", getOption("repos")))',
+      sep = "\n"
+    )
+    stop(msg, call. = FALSE)
+  }
   if(!arrow::arrow_with_gcs()){
     stop("Your {arrow} package installation do not have GCS capabilities. Refer to https://arrow.apache.org/docs/r/articles/install.html")
   }

--- a/man/fetch_data.Rd
+++ b/man/fetch_data.Rd
@@ -29,6 +29,7 @@ Fetch zonal statistics from a product for given municipality code and dates.
 For products with monthly data, like \code{terraclimate}, inform the start and end dates with the fist day of the month. Example: \code{as.Date("2008-06-01")} for June, 2008.
 }
 \examples{
+\dontshow{if (requireNamespace("arrow", quietly = TRUE)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 \dontrun{
 fetch_data(
     code_muni = 3304557,
@@ -39,4 +40,5 @@ fetch_data(
     date_end = as.Date("2008-01-10")
  )
  }
+\dontshow{\}) # examplesIf}
 }

--- a/tests/testthat/test-fetch_data.R
+++ b/tests/testthat/test-fetch_data.R
@@ -1,3 +1,5 @@
+skip_if_not_installed("arrow")
+
 test_that("fetch data from brdwgd works", {
   skip_on_cran()
 


### PR DESCRIPTION
Related to https://github.com/apache/arrow/issues/39806. Since it's not clear that we'll be able to resolve everything with CRAN before February 9, this PR moves arrow from Imports to Suggests. This will prevent your checks failing on CRAN due to arrow's potential archival, but if we don’t get removed, or when we do get back on CRAN, you can revert this.